### PR TITLE
Use CMake 3.18's built-in CMAKE_CUDA_ARCHITECTURES support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_subdirectory(common)
 add_subdirectory(cuda)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 set(altis_common_source_files
     ResultDatabase.cpp

--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -1,11 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
-
-find_package(CUDA)
-set(CUDA_ARCH_LIST Auto CACHE STRING
-    "List of CUDA architectures (e.g. Pascal, Amphere, Volta, etc.) or \
-    compute capability version (6.1, 7.0, etc.) to generate code for. \
-    Set to Auto for automatic detection (default).")
-cuda_select_nvcc_arch_flags(ARCH_FLAGS Auto)
+cmake_minimum_required (VERSION 3.18)
 
 include_directories(common ../common)
 

--- a/src/cuda/level0/CMakeLists.txt
+++ b/src/cuda/level0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_subdirectory(busspeeddownload)
 add_subdirectory(busspeedreadback)

--- a/src/cuda/level0/busspeeddownload/CMakeLists.txt
+++ b/src/cuda/level0/busspeeddownload/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(busspeeddownloadLib BusSpeedDownload.cu)

--- a/src/cuda/level0/busspeedreadback/CMakeLists.txt
+++ b/src/cuda/level0/busspeedreadback/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(busspeedreadbackLib BusSpeedReadback.cu)

--- a/src/cuda/level0/devicememory/CMakeLists.txt
+++ b/src/cuda/level0/devicememory/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(devicememoryLib DeviceMemory.cu)

--- a/src/cuda/level0/maxflops/CMakeLists.txt
+++ b/src/cuda/level0/maxflops/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(maxflopsLib MaxFlops.cu)
 target_compile_options(maxflopsLib PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${ARCH_FLAGS}>)

--- a/src/cuda/level1/CMakeLists.txt
+++ b/src/cuda/level1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_subdirectory(bfs)
 add_subdirectory(gemm)

--- a/src/cuda/level1/bfs/CMakeLists.txt
+++ b/src/cuda/level1/bfs/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(bfsLib bfs.cu)

--- a/src/cuda/level1/gemm/CMakeLists.txt
+++ b/src/cuda/level1/gemm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(gemmLib Gemm.cu)
 target_compile_options(gemmLib PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${ARCH_FLAGS}>)

--- a/src/cuda/level1/gups/CMakeLists.txt
+++ b/src/cuda/level1/gups/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(gupsLib gups.cu)
 target_link_libraries(gupsLib -lm)

--- a/src/cuda/level1/pathfinder/CMakeLists.txt
+++ b/src/cuda/level1/pathfinder/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(pathfinderLib pathfinder.cu)

--- a/src/cuda/level1/sort/CMakeLists.txt
+++ b/src/cuda/level1/sort/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(sortLib Sort.cu sort_kernel.cu)

--- a/src/cuda/level2/CMakeLists.txt
+++ b/src/cuda/level2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_subdirectory(cfd)
 add_subdirectory(dwt2d)

--- a/src/cuda/level2/cfd/CMakeLists.txt
+++ b/src/cuda/level2/cfd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(cfdLib euler3d.cu)
 target_link_libraries(cfdLib -lm)

--- a/src/cuda/level2/dwt2d/CMakeLists.txt
+++ b/src/cuda/level2/dwt2d/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 set(DWT_CUDA_DIR ${CMAKE_CURRENT_LIST_DIR}/dwt_cuda)
 

--- a/src/cuda/level2/kmeans/CMakeLists.txt
+++ b/src/cuda/level2/kmeans/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(kmeansLib
     kmmain.cu

--- a/src/cuda/level2/lavamd/CMakeLists.txt
+++ b/src/cuda/level2/lavamd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(lavamdLib
     lavaMD.cu

--- a/src/cuda/level2/mandelbrot/CMakeLists.txt
+++ b/src/cuda/level2/mandelbrot/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(mandelbrotLib
     mandelbrot.cu

--- a/src/cuda/level2/nw/CMakeLists.txt
+++ b/src/cuda/level2/nw/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(nwLib needle.cu)
 target_link_libraries(nwLib -lm)

--- a/src/cuda/level2/particlefilter/CMakeLists.txt
+++ b/src/cuda/level2/particlefilter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(particlefilterLib ex_particle_CUDA_naive_seq.cu)
 target_link_libraries(particlefilterLib -lm)

--- a/src/cuda/level2/raytracing/CMakeLists.txt
+++ b/src/cuda/level2/raytracing/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_subdirectory(raytracing_cuda)

--- a/src/cuda/level2/raytracing/raytracing_cuda/CMakeLists.txt
+++ b/src/cuda/level2/raytracing/raytracing_cuda/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(raytracingLib raytracing.cu)
 target_link_libraries(raytracingLib -lm)

--- a/src/cuda/level2/srad/CMakeLists.txt
+++ b/src/cuda/level2/srad/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(sradLib
     srad.cu

--- a/src/cuda/level2/where/CMakeLists.txt
+++ b/src/cuda/level2/where/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 
 add_library(whereLib where.cu)
 target_link_libraries(whereLib -lm)


### PR DESCRIPTION
allows Altis to build with Cuda 10.1's nvcc