### PR TITLE
Update to CUDA 12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ src/cuda/level2/dwt2d/input.bmp.dwt.r
 build-aux
 configure
 *m4
+
+# CLion
+cmake-build-*/
+.idea/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CUDA_ARCHITECTURES native)
 
 project(Altis LANGUAGES CXX CUDA)
 


### PR DESCRIPTION
 - [x] Upgrade device-memory benchmark to CUDA 12 (eliminate `texture<...>` in favor of `cudaTextureObject_t`); fixes #24 
 - [x] Auto-detect native SM version